### PR TITLE
hotfix for workflow errors

### DIFF
--- a/.github/workflows/job.yaml
+++ b/.github/workflows/job.yaml
@@ -2,15 +2,22 @@ name: Training Pipeline
 
 on:
   push:
-    branches: [ homework1 ]
+    branches: [ workflow-hotfix ]
 
   workflow_dispatch:
 
 jobs:
   # this workflow contains
+  # python setup, dependency installation,
+  # linting and unit-testing with pytest
+  # as a last step, training pipeline is run
+  # and the artifacts are also saved
   build:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./ml_project
 
     steps:
       - uses: actions/checkout@v3
@@ -21,13 +28,11 @@ jobs:
           architecture: 'x64'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: .
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Checkout to project dir
-        run: |
-          cd ml_project
 
       - name: Lint with Flake8
         run: |
@@ -49,5 +54,5 @@ jobs:
           name: artifacts
           path: |
             *.log
-            artifacts/*.pkl
+            *.pkl
         if: ${{ always() }}

--- a/.github/workflows/job.yaml
+++ b/.github/workflows/job.yaml
@@ -43,16 +43,16 @@ jobs:
       - name: Test with pytest and save the log
         run: |
           python -m pytest -v | tee pytest-results.log
-      
+
       - name: Run the training pipeline
         run: |
-          python pipeline.py | tee pipeline.log
+          python pipeline.py hydra/job_logging=console-dot-formatted | tee pipeline.log
 
       - name: Save the artifacts
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: |
-            *.log
-            *.pkl
+            ./*.log
+            artifacts/*.pkl
         if: ${{ always() }}

--- a/.github/workflows/job.yaml
+++ b/.github/workflows/job.yaml
@@ -2,7 +2,7 @@ name: Training Pipeline
 
 on:
   push:
-    branches: [ workflow-hotfix ]
+    branches: [ homework1 ]
 
   workflow_dispatch:
 

--- a/ml_project/configs/hydra/job_logging/console-dot-formatted.yaml
+++ b/ml_project/configs/hydra/job_logging/console-dot-formatted.yaml
@@ -1,0 +1,19 @@
+version: 1
+formatters:
+  dot-separated:
+    format: '[%(asctime)s]::[%(name)s]::[%(levelname)s]::%(message)s'
+    datefmt: '%D # %H:%M:%S'
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: dot-separated
+    stream: ext://sys.stdout
+  file:
+    class: logging.FileHandler
+    formatter: dot-separated
+    filename: ${hydra.job.name}.log
+root:
+  level: DEBUG
+  handlers: [console]
+
+disable_existing_loggers: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ plotly
 scikit-learn
 requests
 hydra
+hydra-core
 omegaconf
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ plotly
 scikit-learn
 requests
 hydra
+omegaconf
 pytest


### PR DESCRIPTION
Fixed the issues with GitHub's workflows:
At first, I misunderstood the `working-directory` property of the workflow runner (I just `cd ml_project` after installing dependencies). Then, there were problems with the dependencies (`hydra-core` and `omegaconf` did not come with mere `hydra` dependency).
Now pytest and the actual pipeline work fine, but there are problems with artifact uploading as the uploader cannot find required files (I specify these with wildcards like `*.log` and `*.pkl`)

I aim to squash all commits on this branch when merging with `homework1`.